### PR TITLE
Add ability to change the positioning of the image via a class

### DIFF
--- a/lib/kramdown/converter/pdf.rb
+++ b/lib/kramdown/converter/pdf.rb
@@ -162,7 +162,15 @@ module Kramdown
           retry
         end
 
-        options = {position: :center}
+        options = {}
+        if img.attr['class'] =~ /\balign\-left\b/
+          options[:position] = :left
+        elsif img.attr['class'] =~ /\balign\-right\b/
+          options[:position] = :right
+        else
+          options[:position] = :center
+        end
+
         if img.attr['height'] && img.attr['height'] =~ /px$/
           options[:height] = img.attr['height'].to_i / (@options[:image_dpi] || 150.0) * 72
         elsif img.attr['width'] && img.attr['width'] =~ /px$/

--- a/lib/kramdown/converter/pdf.rb
+++ b/lib/kramdown/converter/pdf.rb
@@ -43,7 +43,7 @@ module Kramdown
     #
     class Pdf < Base
 
-      VERSION = '1.0.4'
+      VERSION = '1.0.5'
 
       include Prawn::Measurements
 


### PR DESCRIPTION
I have the need to align images within my converted PDF to the left, but the position is [hard coded](https://github.com/kramdown/converter-pdf/blob/master/lib/kramdown/converter/pdf.rb#L165) to `center` at present. There is support for [using a class to float the image right](https://github.com/kramdown/converter-pdf/blob/master/lib/kramdown/converter/pdf.rb#L174-L176) but there no support (that I see) for floating left, and ideally it would keep the block padding so that the content doesn't become rendered on top of it.