### PR TITLE
Add open_file method to correctly parse urls/paths

### DIFF
--- a/lib/kramdown/converter/pdf.rb
+++ b/lib/kramdown/converter/pdf.rb
@@ -11,6 +11,7 @@ require 'prawn'
 require 'prawn/table'
 require 'kramdown/converter/base'
 require 'kramdown/utils'
+require 'open-uri'
 
 module Kramdown
 

--- a/lib/kramdown/converter/pdf.rb
+++ b/lib/kramdown/converter/pdf.rb
@@ -11,7 +11,6 @@ require 'prawn'
 require 'prawn/table'
 require 'kramdown/converter/base'
 require 'kramdown/utils'
-require 'open-uri'
 
 module Kramdown
 

--- a/lib/kramdown/converter/pdf.rb
+++ b/lib/kramdown/converter/pdf.rb
@@ -155,7 +155,7 @@ module Kramdown
         img_dirs = @options.fetch(:image_directories, []) + ["."]
         path_or_url = img.attr["src"]
         begin
-          image_obj, image_info = @pdf.build_image_object(open(path_or_url))
+          image_obj, image_info = @pdf.build_image_object(open_file(path_or_url))
         rescue StandardError
           raise if img_dirs.empty?
           path_or_url = File.join(img_dirs.shift, img.attr["src"])
@@ -444,6 +444,12 @@ module Kramdown
       end
       alias render_raw render_footnote
       alias render_html_element render_footnote
+
+      def open_file(path_or_url)
+        URI.parse(path_or_url).open
+      rescue URI::InvalidURIError
+        open(path_or_url)
+      end
 
       # ----------------------------
       # :section: Organizational methods


### PR DESCRIPTION
Code fixing issue #8  

This code checks first whether the file being opened is a URL and if it is, opens it accordingly; if the file is not a URL, it opens it as a path.